### PR TITLE
Ignore checking validity of SOA fields. 

### DIFF
--- a/dns_compare.py
+++ b/dns_compare.py
@@ -68,7 +68,7 @@ if opts.zone == None or opts.zonefile == None or opts.nameserver == None:
 	print "Error: required arguments: --zone, --file, --server (or --help)"
 	sys.exit(-1)
 
-z = dns.zone.from_file(opts.zonefile, origin=opts.zone, relativize=False)
+z = dns.zone.from_file(opts.zonefile, origin=opts.zone, relativize=False, check_origin=False)
 
 r = dns.resolver.Resolver(configure=False)
 r.nameservers = [socket.gethostbyname(opts.nameserver)]


### PR DESCRIPTION
When using as a script to check that two name servers have the same data, we should not validate SOA records. (maybe?) =)
